### PR TITLE
Tandem method changes with virtual and override

### DIFF
--- a/src/Main.cs
+++ b/src/Main.cs
@@ -152,7 +152,7 @@ namespace Landis.Extension.LandUse
 
         //---------------------------------------------------------------------
 
-        public new void CleanUp()
+        public override void CleanUp()
         {
             if (SiteLog.Enabled)
                 SiteLog.Close();


### PR DESCRIPTION
Allow Extension-Base-BDA, Extension-LinearWind, Extension-Land-Use-Change to override default implementation of InitalizePhase2() and CleanUp() in Core-Model
